### PR TITLE
Block weights do not seem to work

### DIFF
--- a/src/Plugin/ContextReaction/Blocks.php
+++ b/src/Plugin/ContextReaction/Blocks.php
@@ -148,6 +148,10 @@ class Blocks extends ContextReactionPluginBase implements ContainerFactoryPlugin
 
         $blockContent = $block->build();
 
+        if (($configuration = $block->getConfiguration()) && array_key_exists('weight', $configuration)) {
+          $blockContent['#weight'] = $configuration['weight'];
+        }
+
         // Abort rendering: render as the empty string and ensure this block is
         // render cached, so we can avoid the work of having to repeatedly
         // determine whether the block is empty. E.g. modifying or adding entities


### PR DESCRIPTION
Blocks seem to be output based on the order they are in a single context.

So if I have two contexts, I just get the blocks appended to the list rather than sorted by weight.
