### PR TITLE
Block settings not saved?

### DIFF
--- a/src/Plugin/ContextReaction/Blocks.php
+++ b/src/Plugin/ContextReaction/Blocks.php
@@ -489,6 +489,7 @@ class Blocks extends ContextReactionPluginBase implements ContainerFactoryPlugin
 
     foreach ($blocks as $block_id => $configuration) {
       $block = $this->getBlock($block_id);
+      $configuration += $block->getConfiguration();
 
       $block_state = (new FormState())->setValues($configuration);
       $block->submitConfigurationForm($form, $block_state);


### PR DESCRIPTION
(from https://github.com/oddhill/d8-context/pull/10)

I'm using https://www.drupal.org/project/fieldblock and it works fine in Block Layout.

In context, I see the block and can configure it as usualy (selecting field and display info). I click submit and edit again, and the conf is still present.

When I save the context, the block reaction loses the block config.

This triggers a wonderful WSOD error...

```
The website encountered an unexpected error. Please try again later.

InvalidArgumentException: Field is unknown. in Drupal\Core\Entity\ContentEntityBase->getTranslatedField() (line 474 of core/lib/Drupal/Core/Entity/ContentEntityBase.php).
Drupal\Core\Entity\ContentEntityBase->get(NULL)
Drupal\fieldblock\Plugin\Block\FieldBlock->build()
Drupal\context\Plugin\ContextReaction\Blocks->execute(Array, Object, Array)
Drupal\context\Plugin\DisplayVariant\ContextBlockPageVariant->build()
Drupal\Core\Render\MainContent\HtmlRenderer->prepare(Array, Object, Object)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch('kernel.view', Object)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1)
Stack\StackedHttpKernel->handle(Object, 1, 1)
Drupal\Core\DrupalKernel->handle(Object)
```
