### PR TITLE
ContextBlockPageVariant extends BlockPageVariant t

### DIFF
--- a/src/Plugin/DisplayVariant/ContextBlockPageVariant.php
+++ b/src/Plugin/DisplayVariant/ContextBlockPageVariant.php
@@ -2,11 +2,15 @@
 
 namespace Drupal\context\Plugin\DisplayVariant;
 
-use Drupal\context\ContextManager;
+
+use Drupal\block\BlockRepositoryInterface;
+use Drupal\Core\Entity\EntityViewBuilderInterface;
 use Drupal\Core\Display\VariantBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\block\Plugin\DisplayVariant\BlockPageVariant;
+use Drupal\context\ContextManager;
 use Drupal\Core\Display\PageVariantInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a page display variant that decorates the main content with blocks.
@@ -19,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("Page with blocks")
  * )
  */
-class ContextBlockPageVariant extends VariantBase implements PageVariantInterface, ContainerFactoryPluginInterface {
+class ContextBlockPageVariant extends BlockPageVariant implements PageVariantInterface, ContainerFactoryPluginInterface {
 
   /**
    * @var ContextManager
@@ -27,88 +31,27 @@ class ContextBlockPageVariant extends VariantBase implements PageVariantInterfac
   protected $contextManager;
 
   /**
-   * The render array representing the main page content.
+   * Get the context manager
    *
-   * @var array
+   * @return \Drupal\context\ContextManager|mixed
    */
-  protected $mainContent = [];
-
-  /**
-   * The page title: a string (plain title) or a render array (formatted title).
-   *
-   * @var string|array
-   */
-  protected $title = '';
-
-  /**
-   * Constructs a new ContextBlockPageVariant.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   *
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   *
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   *
-   * @param ContextManager $contextManager
-   *   The context module manager.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ContextManager $contextManager) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->contextManager = $contextManager;
+  private function getContextManager() {
+    if (!isset($this->contextManager)) {
+      $this->contextManager =  \Drupal::service('context.manager');
+    }
+    return $this->contextManager;
   }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('context.manager')
-    );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setMainContent(array $main_content) {
-    $this->mainContent = $main_content;
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setTitle($title) {
-    $this->title = $title;
-    return $this;
-  }
-
+  
   /**
    * {@inheritdoc}
    */
   public function build() {
-    $build = [
-      '#cache' => [
-        'tags' => ['context_block_page', $this->getPluginId()],
-      ],
-    ];
+    $build = parent::build();
 
-    // Place main content and messages blocks, these will be removed by the
-    // reactions if a message or content block has been manually placed.
-    $build['content']['system_main'] = $this->mainContent;
-
-    $build['content']['messages'] = [
-      '#weight' => -1000,
-      '#type' => 'status_messages',
-    ];
+    $reactionblocks = $this->getContextManager()->getActiveReactions('blocks');
 
     // Execute each block reaction and let them modify the page build.
-    foreach ($this->contextManager->getActiveReactions('blocks') as $reaction) {
+    foreach ($reactionblocks as $reaction) {
       $build = $reaction->execute($build, $this->title, $this->mainContent);
     }
 

--- a/src/Plugin/DisplayVariant/ContextBlockPageVariant.php
+++ b/src/Plugin/DisplayVariant/ContextBlockPageVariant.php
@@ -2,11 +2,6 @@
 
 namespace Drupal\context\Plugin\DisplayVariant;
 
-
-use Drupal\block\BlockRepositoryInterface;
-use Drupal\Core\Entity\EntityViewBuilderInterface;
-use Drupal\Core\Display\VariantBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\block\Plugin\DisplayVariant\BlockPageVariant;
 use Drupal\context\ContextManager;
 use Drupal\Core\Display\PageVariantInterface;


### PR DESCRIPTION
In my install I noticed that context and the core block layout did not integrate very well.. after some trial and error I found out that extending the BlockPageVariant instead of the PageVariant solves this problem.

I think there's still some improvement to be made on the getter of the context manager, but I didn't succeed in setting context manager in the constructor.
